### PR TITLE
Prevent nan loss on entmax with quora dataset

### DIFF
--- a/ane_research/models/modules/attention/activations.py
+++ b/ane_research/models/modules/attention/activations.py
@@ -119,8 +119,8 @@ class EntmaxAlphaActivation(AttentionActivationFunction):
         Returns:
             torch.Tensor: Distribution resulting from entmax with specified alpha
         """
-        # Entmax is only defined for alpha >= 1
-        self.alpha.data = torch.clamp(self.alpha.data, min=1.0)
+        # Entmax is only defined for alpha > 1
+        self.alpha.data = torch.clamp(self.alpha.data, min=1.001)
 
         masked_scores = replace_masked_values(scores, mask, -float("inf"))
         return entmax_bisect(masked_scores, self.alpha, dim=-1)


### PR DESCRIPTION
Fixes #17 

Ensures `entmax_bisect` is always called with an alpha >= 1 